### PR TITLE
chore: Update Testcontainers for .NET

### DIFF
--- a/src/apps/cli/SandboxSkill.cs
+++ b/src/apps/cli/SandboxSkill.cs
@@ -1,38 +1,49 @@
+using System.Text;
 using DotNet.Testcontainers.Builders;
-using Microsoft.SemanticKernel.SkillDefinition;
+using DotNet.Testcontainers.Configurations;
+using DotNet.Testcontainers.Containers;
 
 public class SandboxSkill
 {
-    public async Task<string> RunInAlpineAsync(string input)
+    public Task<string> RunInAlpineAsync(string input)
     {
-        return await RunInContainer(input, "alpine");
+        return RunInContainer(input, "alpine:3.18");
     }
 
-    public async Task<string> RunInDotnetAlpineAsync(string input)
+    public Task<string> RunInDotnetAlpineAsync(string input)
     {
-        return await RunInContainer(input, "mcr.microsoft.com/dotnet/sdk:7.0");
+        return RunInContainer(input, "mcr.microsoft.com/dotnet/sdk:7.0-alpine");
     }
 
-    private async Task<string> RunInContainer(string input, string image)
+    private static async Task<string> RunInContainer(string input, string image)
     {
-        var tempScriptFile = $"{Guid.NewGuid().ToString()}.sh";
-        var tempScriptPath = $"./output/{tempScriptFile}";
-        await File.WriteAllTextAsync(tempScriptPath, input);
-        Directory.CreateDirectory(Path.Combine(Directory.GetCurrentDirectory(),"output", "src"));
+        var tempScriptFile = Path.ChangeExtension(Guid.NewGuid().ToString(), "sh");
+
+        var srcDirectoryPath = Path.Combine(Directory.GetCurrentDirectory(), "output", "src");
+        _ = Directory.CreateDirectory(srcDirectoryPath);
+
         var dotnetContainer = new ContainerBuilder()
-                            .WithName(Guid.NewGuid().ToString("D"))
-                            .WithImage(image)
-                            .WithBindMount(Path.Combine(Directory.GetCurrentDirectory(),"output", "src"), "/src")
-                            .WithBindMount(Path.Combine(Directory.GetCurrentDirectory(), tempScriptPath), $"/src/{tempScriptFile}")
-                            .WithWorkingDirectory("/src")
-                            .WithCommand("sh", tempScriptFile)
-                            .Build();
+            .WithImage(image)
+            .WithBindMount(srcDirectoryPath, "/src")
+            .WithResourceMapping(Encoding.Default.GetBytes(input), $"/src/{tempScriptFile}")
+            .WithWaitStrategy(Wait.ForUnixContainer().AddCustomWaitStrategy(new ScriptCompleted()))
+            .WithWorkingDirectory("/src")
+            .WithEntrypoint("/bin/sh")
+            .WithCommand(tempScriptFile)
+            .Build();
 
         await dotnetContainer.StartAsync()
-                            .ConfigureAwait(false);
-        // Cleanup
-        File.Delete(tempScriptPath);
-        File.Delete(Path.Combine(Directory.GetCurrentDirectory(), "output", "src", tempScriptFile));
-        return "";
+            .ConfigureAwait(false);
+
+        File.Delete(Path.Combine(srcDirectoryPath, tempScriptFile));
+        return string.Empty;
+    }
+
+    private sealed class ScriptCompleted : IWaitUntil
+    {
+        public Task<bool> UntilAsync(IContainer container)
+        {
+            return Task.FromResult(TestcontainersStates.Exited.Equals(container.State));
+        }
     }
 }

--- a/src/apps/cli/cli.csproj
+++ b/src/apps/cli/cli.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="Microsoft.SemanticKernel" Version="0.24.230918.1-preview" />
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.Memory.Qdrant" Version="0.24.230918.1-preview" />
-    <PackageReference Include="Testcontainers" Version="3.2.0" />
+    <PackageReference Include="Testcontainers" Version="3.5.0" />
     <ProjectReference Include="..\..\libs\skills\skills.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## What does this PR do?

Hi 👋, I noticed that the project is currently using an outdated version of Testcontainers for .NET. This pull request updates the version to the latest release. 

Furthermore, this pull request applies Testcontainers' best practices. It is typically preferred to utilize the `WithResourceMapping` API to copy files into the container rather than binding them. This is especially crucial when dealing with different Docker environments, as binding a volume can sometimes fail, particularly in remote Docker setups. This also eliminates the need to create the temporary script file on the test host.

Furthermore, I have introduced a wait strategy as part of this pull request. Wait strategies are necessary to indicate the readiness of the container (service inside the container) or serving as a status indicator once the container's entry point has completed its execution.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->