### PR TITLE
[Marketing] Carlos trying pipelines 1: Adding Environment name

### DIFF
--- a/.github/workflows/marketing-builddeploy.yml
+++ b/.github/workflows/marketing-builddeploy.yml
@@ -38,7 +38,11 @@ defaults:
     working-directory: ./samples/marketing
 
 jobs:
-  build:
+  deployment:
+
+    # Environment is going to be used by GitHub to create the subject of the federated identity.
+    environment: dev
+    
     runs-on: ubuntu-latest
     env:
       AZURE_SUBSCRIPTION_ID: ${{ secrets.MARKETING_AZURE_SUBSCRIPTION_ID }}


### PR DESCRIPTION
By adding environments, I can configure the subject identifier in Entra as:
repo:microsoft/project-oagents:environment:<environment>

This way, we can use the same credentials from pull request, manual triggers, etc